### PR TITLE
Fix connection refused errors

### DIFF
--- a/smart-bus/frontend/vite.config.ts
+++ b/smart-bus/frontend/vite.config.ts
@@ -4,4 +4,16 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    host: '0.0.0.0',
+    port: 5173,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8000',
+        changeOrigin: true,
+        ws: true,
+        rewrite: (path: string) => path.replace(/^\/api/, ''),
+      },
+    },
+  },
 })


### PR DESCRIPTION
Configure Vite dev proxy and normalize API base URL in `App.tsx` to fix `ERR_CONNECTION_REFUSED` by making API calls more robust and providing better error handling.

The frontend was directly calling `http://localhost:8000` which led to connection refused errors when the backend was not running or the `VITE_API_BASE` environment variable was malformed. This PR introduces a Vite proxy for `/api` requests to `http://localhost:8000` in development, normalizes the `API_BASE` to default to `/api` (or `window.location.origin` in production), and adds a `try/catch` block to display user-friendly alerts on API call failures.

---
<a href="https://cursor.com/background-agent?bcId=bc-5cd4004a-b561-4de0-a8ed-b779661e50a9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5cd4004a-b561-4de0-a8ed-b779661e50a9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

